### PR TITLE
add java 1.7 dependency in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,14 @@
 	<build>
 		<plugins>
 			<plugin>
+                               <artifactId>maven-compiler-plugin</artifactId>
+                               <version>3.2</version>
+                               <configuration>
+                                   <source>1.7</source>
+                                   <target>1.7</target>
+                               </configuration>
+                        </plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>3.0.0</version>


### PR DESCRIPTION
If we are to use plugins in maven, might as well add the dependency for try with resources.